### PR TITLE
refactor: ownership change (closes #1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bitshepherds/JSM-Approvers

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   Copyright 2026 Andy Ballingall
+   Copyright 2026 Andy Ballingall and Bit Shepherds Limited
 
    1. Definitions.
 
@@ -188,7 +188,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Andy Ballingall
+   Copyright 2026 Andy Ballingall and Bit Shepherds Limited
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ JSON Schema Maanager (JSM) makes this easy.
 
 We welcome contributions of any kind, but please follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Maintainers
+
+This project is jointly owned by:
+
+- Andy Ballingall
+- Bit Shepherds Limited
+
 > [!TIP]
 >
-> If you'd like to help with the development of JSM itself (i.e. the `jsm` CLI tool), head over to [github.com/andyballingall/json-schema-manager](https://github.com/andyballingall/json-schema-manager).
+> If you'd like to help with the development of JSM itself (i.e. the `jsm` CLI tool), head over to [github.com/bitshepherds/json-schema-manager](https://github.com/bitshepherds/json-schema-manager).
 
 ## Licence
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -30,7 +30,7 @@ This tutorial will walk you through the features of JSON Schema Manager (JSM).
 ## 1. Clone this repo
 
 ```bash
-git clone https://github.com/andyballingall/jsm-demo.git
+git clone https://github.com/bitshepherds/jsm-demo.git
 cd jsm-demo
 ```
 
@@ -61,7 +61,7 @@ jsm -v
 
 > [!NOTE]
 >
-> You can also download the latest release from [GitHub](https://github.com/andyballingall/json-schema-manager/releases).
+> You can also download the latest release from [GitHub](https://github.com/bitshepherds/json-schema-manager/releases).
 
 ## 3. Introducing the registry
 
@@ -423,4 +423,3 @@ jsm validate -w -v -r tutorial finance/payments/
 ## 8. Composing schemas
 
 The data that JSON Schema is used to validate is often highly structured and complex, especially in enterprise situations. Additionally, the same sub-structures are often used many times in different schemas. Simple examples might be addresses, or the specific format of a customer-facing ID, but for our schema example, let's imagine we want to capture the location of the device that generated the payment instruction.
-


### PR DESCRIPTION
## Summary
Update all references from `andyballingall` to `bitshepherds` following the repo transfer from personal account to organisation.
## Changes
- **LICENSE** - Updated copyright to "Andy Ballingall and Bit Shepherds Limited" (joint ownership)
- **README.md** - Added Maintainers section documenting joint ownership; updated links to point to `bitshepherds/json-schema-manager`
- **docs/tutorial.md** - Updated clone URL and release download URL to point to org repo
- **.github/CODEOWNERS** - Created with `* @bitshepherds/JSM-Approvers`
## Notes
- Git remote already correctly pointed to `bitshepherds/jsm-demo.git` (no change needed)
- The `json-schema-manager` CLI tool repo was also transferred, so tutorial links now point to the org location